### PR TITLE
[#2] replace abstract class with mixin

### DIFF
--- a/generator/lib/src/writer/writer.dart
+++ b/generator/lib/src/writer/writer.dart
@@ -13,7 +13,7 @@ class Writer {
   }
 
   void _generate() {
-    _w.writeln('abstract class _${_b.name} implements Bean<${_b.modelType}> {');
+    _w.writeln('mixin _${_b.name} implements Bean<${_b.modelType}> {');
 
     for (Field field in _b.fields.values) {
       _writeln(


### PR DESCRIPTION
This PR fixes the issue with not allowed abstract class (The class '_ClassName' can't be used as a mixin because it's neither a mixin class nor a mixin. (Documentation))